### PR TITLE
feat: add password visibility toggle in signup and login screens

### DIFF
--- a/NewsYork/View/LoginVC.swift
+++ b/NewsYork/View/LoginVC.swift
@@ -15,6 +15,8 @@ class LoginVC: UIViewController {
     @IBOutlet weak var signupLinkButton: UIButton!
     @IBOutlet weak var forgotLinkButton: UIButton!
     
+    private var eyeButtonForPassword = UIButton(type: .custom)
+    
     private var viewModel = LoginVM()
     
     override func viewDidLoad() {
@@ -22,6 +24,7 @@ class LoginVC: UIViewController {
         
         setupBindings()
         checkRememberMe()
+        addPasswordVisibilityButton()
 
     }
     
@@ -35,6 +38,20 @@ class LoginVC: UIViewController {
                 }
             }
         }
+    }
+    
+    func addPasswordVisibilityButton() {
+        eyeButtonForPassword.setImage(UIImage(systemName: "eye"), for: .normal)
+        eyeButtonForPassword.addTarget(self, action: #selector(togglePasswordVisibility), for: .touchUpInside)
+        eyeButtonForPassword.tintColor = .systemGray
+        passwordTextField.rightView = eyeButtonForPassword
+        passwordTextField.rightViewMode = .always
+    }
+    
+    @objc func togglePasswordVisibility() {
+        passwordTextField.isSecureTextEntry.toggle()
+        let eyeImageName = passwordTextField.isSecureTextEntry ? "eye" : "eye.slash"
+        eyeButtonForPassword.setImage(UIImage(systemName: eyeImageName), for: .normal)
     }
     
     func checkRememberMe() {

--- a/NewsYork/View/SignupVC.swift
+++ b/NewsYork/View/SignupVC.swift
@@ -17,11 +17,15 @@ class SignupVC: UIViewController {
     @IBOutlet weak var passwordTextField: UITextField!
     @IBOutlet weak var confirmPasswordTextField: UITextField!
     
+    private var eyeButtonForPassword = UIButton(type: .custom)
+    private var eyeButtonForConfirmPassword = UIButton(type: .custom)
+    
     private var viewModel = SignupVM()
     
     override func viewDidLoad() {
         super.viewDidLoad()
         setupViewModel()
+        addPasswordVisibilityButton()
     }
     
     func setupViewModel() {
@@ -38,6 +42,32 @@ class SignupVC: UIViewController {
                 })
             }
         }
+    }
+    
+    func addPasswordVisibilityButton() {
+        eyeButtonForPassword.setImage(UIImage(systemName: "eye"), for: .normal)
+        eyeButtonForPassword.addTarget(self, action: #selector(togglePasswordVisibility), for: .touchUpInside)
+        eyeButtonForPassword.tintColor = .systemGray
+        passwordTextField.rightView = eyeButtonForPassword
+        passwordTextField.rightViewMode = .always
+        
+        eyeButtonForConfirmPassword.setImage(UIImage(systemName: "eye"), for: .normal)
+        eyeButtonForConfirmPassword.addTarget(self, action: #selector(toggleConfirmPasswordVisibility), for: .touchUpInside)
+        eyeButtonForConfirmPassword.tintColor = .systemGray
+        confirmPasswordTextField.rightView = eyeButtonForConfirmPassword
+        confirmPasswordTextField.rightViewMode = .always
+    }
+    
+    @objc func togglePasswordVisibility() {
+        passwordTextField.isSecureTextEntry.toggle()
+        let eyeImageName = passwordTextField.isSecureTextEntry ? "eye" : "eye.slash"
+        eyeButtonForPassword.setImage(UIImage(systemName: eyeImageName), for: .normal)
+    }
+    
+    @objc func toggleConfirmPasswordVisibility() {
+        confirmPasswordTextField.isSecureTextEntry.toggle()
+        let eyeImageName = confirmPasswordTextField.isSecureTextEntry ? "eye" : "eye.slash"
+        eyeButtonForConfirmPassword.setImage(UIImage(systemName: eyeImageName), for: .normal)
     }
     
     @IBAction func signupButtonClicked(_ sender: Any) {


### PR DESCRIPTION
- Implemented eye icon button for toggling password visibility in both Signup and Login screens.
- Used SF Symbols for the eye icon and applied tint color for customization.
- Improved user experience by allowing users to toggle password visibility on and off.